### PR TITLE
Wait for UI and API health endpoints

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -7,6 +7,6 @@ PLAYWRIGHT_API_URL=http://backend:8000/api/v1
 # Optional expect timeout override (ms)
 # PLAYWRIGHT_EXPECT_TIMEOUT=10000
 
-# Optional health-check endpoint for docker/CI waits
-# PLAYWRIGHT_HEALTHCHECK_URL=http://frontend:3000/health
-# PLAYWRIGHT_API_HEALTHCHECK_URL=http://backend:8000/health
+# Optional health-check endpoints for docker/CI waits
+# PLAYWRIGHT_HEALTHCHECK_URL=http://frontend:3000
+# PLAYWRIGHT_API_HEALTHCHECK_URL=http://backend:8000/api/v1/health

--- a/README.md
+++ b/README.md
@@ -33,8 +33,8 @@ Available variables:
 - `PLAYWRIGHT_BASE_URL`: Base URL for UI tests (defaults to `http://frontend:3000`).
 - `PLAYWRIGHT_API_URL`: Base URL for API tests (defaults to `http://backend:8000/api/v1`).
 - `PLAYWRIGHT_EXPECT_TIMEOUT`: Expectation timeout override in milliseconds (optional).
-- `PLAYWRIGHT_HEALTHCHECK_URL`: Endpoint polled before UI tests run (optional).
-- `PLAYWRIGHT_API_HEALTHCHECK_URL`: Endpoint polled before API tests run (optional).
+- `PLAYWRIGHT_HEALTHCHECK_URL`: Endpoint polled before UI tests run (optional). Falls back to `PLAYWRIGHT_BASE_URL`.
+- `PLAYWRIGHT_API_HEALTHCHECK_URL`: Endpoint polled before API tests run (optional). Falls back to `${PLAYWRIGHT_API_URL}/health` (for PeithoTest this resolves to `/api/v1/health`).
 
 ### 3. Run tests locally
 
@@ -58,7 +58,8 @@ npm run test:ui -- --headed --debug
 ### 4. Run tests via Docker
 
 Build and execute the Playwright container using Docker Compose. The tests will run against the
-URLs defined in your `.env` file.
+URLs defined in your `.env` file. The Compose command now waits for both the UI and API health
+endpoints so that login flows do not start while the backend is still returning `404`.
 
 ```bash
 docker compose up --build

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -12,9 +12,12 @@ services:
       - ./playwright-report:/app/playwright-report
     command: >-
       bash -lc "\
-        HEALTH_URL=${PLAYWRIGHT_HEALTHCHECK_URL:-$${PLAYWRIGHT_BASE_URL}/health} && \
-        echo \"Waiting for $$HEALTH_URL\" && \
-        npx ts-node --project tsconfig.json scripts/wait-for-service.ts $$HEALTH_URL 180000 5000 && \
+        UI_HEALTH_URL=${PLAYWRIGHT_HEALTHCHECK_URL:-$${PLAYWRIGHT_BASE_URL}} && \
+        API_HEALTH_URL=${PLAYWRIGHT_API_HEALTHCHECK_URL:-$${PLAYWRIGHT_API_URL}/health} && \
+        echo \"Waiting for $$UI_HEALTH_URL\" && \
+        npx ts-node --project tsconfig.json scripts/wait-for-service.ts $$UI_HEALTH_URL 180000 5000 && \
+        echo \"Waiting for $$API_HEALTH_URL\" && \
+        npx ts-node --project tsconfig.json scripts/wait-for-service.ts $$API_HEALTH_URL 180000 5000 && \
         npx playwright test --reporter=html,list\
       "
 


### PR DESCRIPTION
## Summary
- update the Playwright docker-compose command to wait on both the UI base URL and the API health endpoint before running tests
- document the new defaults and correct API health check path in the README and example environment file

## Testing
- npx playwright test --list

------
https://chatgpt.com/codex/tasks/task_e_68ce66884f6c832a8a6d277ec366b52c