### PR TITLE
chore: bump Playwright to v1.55.0

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -426,20 +426,19 @@
       }
     },
     "node_modules/@playwright/test": {
-      "version": "1.41.2",
-      "resolved": "https://registry.npmjs.org/@playwright/test/-/test-1.41.2.tgz",
-      "integrity": "sha512-qQB9h7KbibJzrDpkXkYvsmiDJK14FULCCZgEcoe2AvFAS64oCirWTwzTlAYEbKaRxWs5TFesE1Na6izMv3HfGg==",
-      "deprecated": "Please update to the latest version of Playwright to test up-to-date browsers.",
+      "version": "1.55.0",
+      "resolved": "https://registry.npmjs.org/@playwright/test/-/test-1.55.0.tgz",
+      "integrity": "sha512-3sWdvyIt0ZJ3KjLa6Gh1SGzSYviPhZdrKS3WgN4c0Vi1p84zLpryizZn8AiEwl2eEWFTrtVRpgKiT5pS0zM8xA==",
       "dev": true,
       "license": "Apache-2.0",
       "dependencies": {
-        "playwright": "1.41.2"
+        "playwright": "1.55.0"
       },
       "bin": {
         "playwright": "cli.js"
       },
       "engines": {
-        "node": ">=16"
+        "node": ">=18"
       }
     },
     "node_modules/@tsconfig/node10": {
@@ -1622,19 +1621,19 @@
       }
     },
     "node_modules/playwright": {
-      "version": "1.41.2",
-      "resolved": "https://registry.npmjs.org/playwright/-/playwright-1.41.2.tgz",
-      "integrity": "sha512-v0bOa6H2GJChDL8pAeLa/LZC4feoAMbSQm1/jF/ySsWWoaNItvrMP7GEkvEEFyCTUYKMxjQKaTSg5up7nR6/8A==",
+      "version": "1.55.0",
+      "resolved": "https://registry.npmjs.org/playwright/-/playwright-1.55.0.tgz",
+      "integrity": "sha512-wyQSMRu5jgIFnO8G0QpMUx1M/pBT8fbOFBG4Vn6ECkeB4tsqm8zxFRVWTntjMjlSiz32x2ndFCJecWj4YnOhhg==",
       "dev": true,
       "license": "Apache-2.0",
       "dependencies": {
-        "playwright-core": "1.41.2"
+        "playwright-core": "1.55.0"
       },
       "bin": {
         "playwright": "cli.js"
       },
       "engines": {
-        "node": ">=16"
+        "node": ">=18"
       },
       "optionalDependencies": {
         "fsevents": "2.3.2"
@@ -1655,16 +1654,16 @@
       }
     },
     "node_modules/playwright/node_modules/playwright-core": {
-      "version": "1.41.2",
-      "resolved": "https://registry.npmjs.org/playwright-core/-/playwright-core-1.41.2.tgz",
-      "integrity": "sha512-VaTvwCA4Y8kxEe+kfm2+uUUw5Lubf38RxF7FpBxLPmGe5sdNkSg5e3ChEigaGrX7qdqT3pt2m/98LiyvU2x6CA==",
+      "version": "1.55.0",
+      "resolved": "https://registry.npmjs.org/playwright-core/-/playwright-core-1.55.0.tgz",
+      "integrity": "sha512-GvZs4vU3U5ro2nZpeiwyb0zuFaqb9sUiAJuyrWpcGouD8y9/HLgGbNRjIph7zU9D3hnPaisMl9zG9CgFi/biIg==",
       "dev": true,
       "license": "Apache-2.0",
       "bin": {
         "playwright-core": "cli.js"
       },
       "engines": {
-        "node": ">=16"
+        "node": ">=18"
       }
     },
     "node_modules/prettier": {

--- a/package.json
+++ b/package.json
@@ -18,7 +18,7 @@
   },
   "devDependencies": {
     "@axe-core/playwright": "^4.10.2",
-    "@playwright/test": "1.41.2",
+    "@playwright/test": "1.55.0",
     "@types/node": "^20.11.17",
     "dotenv": "^16.3.1",
     "nyc": "^17.1.0",


### PR DESCRIPTION
## Summary
- bump @playwright/test to 1.55.0 in package.json
- update package-lock.json to lock the Playwright 1.55.0 toolchain

## Testing
- not run (network restrictions prevented reinstalling dependencies)

------
https://chatgpt.com/codex/tasks/task_e_68d15e7bd708832abd2903e979559b37