### PR TITLE
Remove campaign validation tests and update Playwright projects

### DIFF
--- a/playwright.config.ts
+++ b/playwright.config.ts
@@ -28,8 +28,8 @@ export default defineConfig({
   ],
   use: {
     trace: 'on-first-retry',
-    video: 'retain-on-failure',
-    screenshot: 'only-on-failure',
+    video: 'on',
+    screenshot: 'on',
     ignoreHTTPSErrors: true,
   },
   expect: {
@@ -46,13 +46,13 @@ export default defineConfig({
       outputDir: projectOutputDir('ui-chromium'),
     },
     {
-      name: 'iphone-12',
+      name: 'firefox',
       testDir: e2eTestDir,
       use: {
-        ...devices['iPhone 12'],
+        ...devices['Desktop Firefox'],
         baseURL: baseUiUrl,
       },
-      outputDir: projectOutputDir('ui-iphone-12'),
+      outputDir: projectOutputDir('ui-firefox'),
     },
     {
       name: 'api',

--- a/tests/e2e/campaigns.spec.ts
+++ b/tests/e2e/campaigns.spec.ts
@@ -1,6 +1,5 @@
 import { test, expect } from "@playwright/test";
 import type { Page } from "@playwright/test";
-import AxeBuilder from "@axe-core/playwright";
 
 import { getAdminCredentials } from "../data/admin-credentials";
 import { LoginPage } from "./pom/LoginPage";
@@ -27,26 +26,6 @@ test.describe("Campaign management", () => {
     await authenticate(page);
   });
 
-  test("campaign dashboard section has no critical accessibility regressions", async ({
-    page,
-  }) => {
-    const campaignListPage = new CampaignListPage(page);
-    await campaignListPage.goto();
-    await expect(campaignListPage.heading).toBeVisible();
-
-    const contentSectionHandle = await campaignListPage.contentSection.elementHandle();
-    if (!contentSectionHandle) {
-      throw new Error(
-        "Expected campaign list content section to be available for accessibility analysis",
-      );
-    }
-
-    const results = await new AxeBuilder({ page })
-      .include(contentSectionHandle)
-      .analyze();
-
-    expect(results.violations).toEqual([]);
-  });
 
   test("creates a campaign and lands on its detail view", async ({ page }) => {
     const campaignListPage = new CampaignListPage(page);
@@ -74,28 +53,6 @@ test.describe("Campaign management", () => {
     await expect(detailPage.headingWithName(campaignName)).toBeVisible();
   });
 
-  test("blocks campaign creation when no connector is selected", async ({
-    page,
-  }) => {
-    const campaignListPage = new CampaignListPage(page);
-    await campaignListPage.goto();
-    await campaignListPage.startNewCampaign();
-
-    const newCampaignPage = new NewCampaignPage(page);
-    await expect(newCampaignPage.heading).toBeVisible();
-
-    const campaignName = `Missing Connector ${Date.now()}`;
-    await newCampaignPage.fillName(campaignName);
-    await newCampaignPage.fillInitialPrompt(
-      "Prompt without connector selection.",
-    );
-    await newCampaignPage.addObjective(
-      "Ensure validation prevents submission.",
-    );
-    await newCampaignPage.submit();
-
-    await expect(newCampaignPage.missingConnectorError).toBeVisible();
-  });
 
   test("deletes a campaign from detail view and removes it from the list", async ({
     page,


### PR DESCRIPTION
## Summary
- remove unneeded accessibility and connector validation campaign tests
- enable always-on screenshots and videos while replacing the iPhone project with Firefox coverage

## Testing
- npx playwright test --list

------
https://chatgpt.com/codex/tasks/task_e_68d185c95b78832a9b744e7fe5903e29