### PR TITLE
Add Allure reporting and GitHub Pages publishing

### DIFF
--- a/.github/workflows/peithotest-e2e.yml
+++ b/.github/workflows/peithotest-e2e.yml
@@ -4,7 +4,7 @@ on:
   workflow_dispatch:
 
 permissions:
-  contents: read
+  contents: write
 
 env:
   PRIVATE_REPO_SSH: git@github.com:tboulord/PeithoTest.git
@@ -82,6 +82,34 @@ jobs:
         with:
           name: playwright-test-results
           path: test-results
+          if-no-files-found: ignore
+          retention-days: 14
+
+      - name: Upload Allure results
+        if: always()
+        uses: actions/upload-artifact@v4
+        with:
+          name: allure-results
+          path: allure-results
+          if-no-files-found: ignore
+          retention-days: 14
+
+      - name: Publish Allure report to GitHub Pages
+        if: github.event_name == 'push' && hashFiles('allure-results/**/*') != ''
+        uses: simple-elf/allure-report-action@master
+        with:
+          github_token: ${{ secrets.GITHUB_TOKEN }}
+          allure_results: allure-results
+          allure_report: allure-report
+          gh_pages: gh-pages
+          keep_reports: 20
+
+      - name: Upload Allure report
+        if: github.event_name == 'push' && hashFiles('allure-report/**/*') != ''
+        uses: actions/upload-artifact@v4
+        with:
+          name: allure-report
+          path: allure-report
           if-no-files-found: ignore
           retention-days: 14
 

--- a/.gitignore
+++ b/.gitignore
@@ -1,4 +1,6 @@
 node_modules/
 playwright-report/
 test-results/
+allure-results/
+allure-report/
 .DS_Store

--- a/README.md
+++ b/README.md
@@ -12,6 +12,7 @@ Playwright reports as workflow artifacts.
   deploy keys, build the application with `docker-compose`, and run the tests.
 - Shared fixtures and data helpers that keep test code lean and focused on behaviour.
 - Video capture enabled for every UI test run to simplify debugging.
+- Allure-compatible reporter with automated GitHub Pages publishing for rich test analytics.
 
 ## Test Suite Layout
 
@@ -159,11 +160,28 @@ During CI the workflow will:
 - Start the PeithoTest stack using its `docker-compose.yml` file.
 - Execute the Playwright UI suite.
 - Upload the Playwright HTML report and traces as workflow artifacts.
+- Publish Allure results as artifacts and promote the HTML dashboard to GitHub Pages for easy sharing.
 
 The `peithotest-e2e.yml` workflow still clones the private application repository before booting the
 stack. With `docker-compose` exposing the frontend (`3000:3000`), backend (`8000:8000`), and mock
 chatbot (`8080:8080`) services on the GitHub runner, the Playwright job can rely on the documented
 `PLAYWRIGHT_BASE_URL` and `PLAYWRIGHT_API_URL` defaults to reach the stack over `localhost`.
+
+### Allure reporting
+
+Every Playwright execution now emits Allure-compatible JSON results under `allure-results/`.
+To review them locally install the Allure CLI (for example via
+[`npm install -g allure-commandline`](https://docs.qameta.io/allure/#_get_started)) and run:
+
+```bash
+allure generate allure-results --clean -o allure-report
+allure open allure-report
+```
+
+In CI the workflow relies on the community `simple-elf/allure-report-action` to transform the
+results into the familiar Allure HTML dashboard and push it to the `gh-pages` branch. The latest
+report is therefore always available through the repository's GitHub Pages site without requiring a
+manual download from the Actions UI.
 
 ## Repository Layout
 

--- a/playwright.config.ts
+++ b/playwright.config.ts
@@ -24,7 +24,8 @@ export default defineConfig({
   workers: process.env.CI ? 4 : undefined,
   reporter: [
     ['list'],
-    ['html', { open: 'never' }]
+    ['html', { open: 'never' }],
+    ['./tests/reporters/simple-allure-reporter.ts']
   ],
   use: {
     trace: 'on-first-retry',

--- a/tests/reporters/simple-allure-reporter.ts
+++ b/tests/reporters/simple-allure-reporter.ts
@@ -1,0 +1,279 @@
+import type { FullConfig, Reporter, Suite, TestCase, TestResult } from '@playwright/test/reporter';
+import { randomUUID, createHash } from 'crypto';
+import fs from 'fs';
+import path from 'path';
+
+interface AllureLabel {
+  name: string;
+  value: string;
+}
+
+interface AllureAttachment {
+  name: string;
+  type?: string;
+  source: string;
+}
+
+interface AllureStatusDetails {
+  message?: string;
+  trace?: string;
+}
+
+interface AllureTime {
+  start: number;
+  stop: number;
+  duration: number;
+}
+
+interface AllureResultPayload {
+  uuid: string;
+  name: string;
+  fullName: string;
+  historyId: string;
+  testCaseId: string;
+  status: 'passed' | 'failed' | 'broken' | 'skipped' | 'unknown';
+  statusDetails: AllureStatusDetails;
+  stage: 'finished';
+  steps: unknown[];
+  attachments: AllureAttachment[];
+  parameters: { name: string; value: string }[];
+  labels: AllureLabel[];
+  links: unknown[];
+  time: AllureTime;
+}
+
+interface AllureContainerPayload {
+  uuid: string;
+  name: string;
+  children: string[];
+  befores: unknown[];
+  afters: unknown[];
+  links: unknown[];
+  start: number;
+  stop: number;
+}
+
+interface RunningTestInfo {
+  uuid: string;
+  containerUuid: string;
+  start: number;
+}
+
+const { version: playwrightVersion } = require('@playwright/test/package.json');
+
+class SimpleAllureReporter implements Reporter {
+  private resultsDir!: string;
+  private tests = new Map<TestResult, RunningTestInfo>();
+
+  onBegin(config: FullConfig, suite: Suite) {
+    const configured = process.env.ALLURE_RESULTS_DIR;
+    const dir = configured ? path.resolve(configured) : path.resolve(process.cwd(), 'allure-results');
+    this.resultsDir = dir;
+    fs.rmSync(this.resultsDir, { force: true, recursive: true });
+    fs.mkdirSync(this.resultsDir, { recursive: true });
+    this.writeExecutorInfo(config, suite);
+  }
+
+  onTestBegin(test: TestCase, result: TestResult) {
+    const start = result.startTime?.getTime?.() ?? Date.now();
+    this.tests.set(result, {
+      uuid: randomUUID(),
+      containerUuid: randomUUID(),
+      start,
+    });
+  }
+
+  onTestEnd(test: TestCase, result: TestResult) {
+    const meta = this.tests.get(result);
+    if (!meta) {
+      return;
+    }
+
+    const stop = meta.start + (result.duration ?? 0);
+    const labels = this.buildLabels(test, result);
+    const fullName = this.buildFullName(test);
+    const historyId = this.hash(fullName);
+    const testLocation = this.describeLocation(test);
+    const testCaseId = this.hash(testLocation);
+
+    const attachments = this.collectAttachments(result, meta.uuid);
+    const payload: AllureResultPayload = {
+      uuid: meta.uuid,
+      name: test.title,
+      fullName,
+      historyId,
+      testCaseId,
+      status: this.mapStatus(result.status, result.error),
+      statusDetails: {
+        message: result.error?.message,
+        trace: result.error?.stack,
+      },
+      stage: 'finished',
+      steps: [],
+      attachments,
+      parameters: this.buildParameters(result),
+      labels,
+      links: [],
+      time: {
+        start: meta.start,
+        stop,
+        duration: Math.max(0, stop - meta.start),
+      },
+    };
+
+    this.writeJson(`${meta.uuid}-result.json`, payload);
+
+    const container: AllureContainerPayload = {
+      uuid: meta.containerUuid,
+      name: this.computeContainerName(test),
+      children: [meta.uuid],
+      befores: [],
+      afters: [],
+      links: [],
+      start: meta.start,
+      stop,
+    };
+
+    this.writeJson(`${meta.containerUuid}-container.json`, container);
+    this.tests.delete(result);
+  }
+
+  private buildParameters(result: TestResult) {
+    const parameters: { name: string; value: string }[] = [];
+    if (result.projectName) {
+      parameters.push({ name: 'Project', value: result.projectName });
+    }
+    if (typeof result.retry === 'number') {
+      parameters.push({ name: 'Retry', value: String(result.retry) });
+    }
+    return parameters;
+  }
+
+  private describeLocation(test: TestCase) {
+    const { file, line, column } = test.location ?? {};
+    return [test.id, file, line, column].filter((part) => part !== undefined).join(':');
+  }
+
+  private buildLabels(test: TestCase, result: TestResult): AllureLabel[] {
+    const titles = test.titlePath();
+    const parentSuites = titles.slice(1, -1);
+    const labels: AllureLabel[] = [
+      { name: 'language', value: 'TypeScript' },
+      { name: 'framework', value: 'Playwright' },
+      { name: 'package', value: test.location?.file ?? '' },
+    ];
+
+    if (parentSuites.length > 0) {
+      labels.push({ name: 'parentSuite', value: parentSuites[0] });
+      if (parentSuites.length > 1) {
+        labels.push({ name: 'suite', value: parentSuites.slice(1).join(' > ') });
+      }
+    }
+    if (result.projectName) {
+      labels.push({ name: 'thread', value: result.projectName });
+    }
+    labels.push({ name: 'host', value: process.env.HOSTNAME ?? 'localhost' });
+    labels.push({ name: 'frameworkVersion', value: playwrightVersion });
+    return labels;
+  }
+
+  private buildFullName(test: TestCase) {
+    return test.titlePath().join(' › ');
+  }
+
+  private computeContainerName(test: TestCase) {
+    const titles = test.titlePath();
+    return titles.slice(0, -1).join(' › ') || 'Global';
+  }
+
+  private collectAttachments(result: TestResult, baseUuid: string): AllureAttachment[] {
+    const attachments: AllureAttachment[] = [];
+    for (const [index, attachment] of result.attachments.entries()) {
+      if (!attachment.path && !attachment.body) {
+        continue;
+      }
+      const extension = this.extensionForContentType(attachment.contentType) ?? path.extname(attachment.path ?? '') ?? '';
+      const fileName = `${baseUuid}-attachment-${index}${extension}`;
+      const destination = path.join(this.resultsDir, fileName);
+      try {
+        if (attachment.path) {
+          fs.copyFileSync(attachment.path, destination);
+        } else if (attachment.body) {
+          const buffer = typeof attachment.body === 'string' ? Buffer.from(attachment.body) : attachment.body;
+          fs.writeFileSync(destination, buffer);
+        }
+        attachments.push({ name: attachment.name, type: attachment.contentType, source: fileName });
+      } catch (error) {
+        console.warn(`Failed to persist Allure attachment ${attachment.name}:`, error);
+      }
+    }
+    return attachments;
+  }
+
+  private extensionForContentType(contentType?: string | null): string | undefined {
+    if (!contentType) {
+      return undefined;
+    }
+    if (contentType.includes('png')) {
+      return '.png';
+    }
+    if (contentType.includes('jpeg') || contentType.includes('jpg')) {
+      return '.jpg';
+    }
+    if (contentType.includes('zip')) {
+      return '.zip';
+    }
+    if (contentType.includes('json')) {
+      return '.json';
+    }
+    if (contentType.includes('plain')) {
+      return '.txt';
+    }
+    return undefined;
+  }
+
+  private mapStatus(status: TestResult['status'], error?: TestResult['error']): AllureResultPayload['status'] {
+    switch (status) {
+      case 'passed':
+        return 'passed';
+      case 'skipped':
+        return 'skipped';
+      case 'failed':
+        return 'failed';
+      case 'timedOut':
+        return 'broken';
+      case 'interrupted':
+        return 'broken';
+      default:
+        return error ? 'failed' : 'unknown';
+    }
+  }
+
+  private writeExecutorInfo(config: FullConfig, suite: Suite) {
+    const executor = {
+      name: 'Playwright',
+      type: 'playwright',
+      url: process.env.GITHUB_SERVER_URL && process.env.GITHUB_REPOSITORY
+        ? `${process.env.GITHUB_SERVER_URL}/${process.env.GITHUB_REPOSITORY}`
+        : undefined,
+      buildOrder: process.env.GITHUB_RUN_NUMBER,
+      buildName: process.env.GITHUB_WORKFLOW,
+      buildUrl: process.env.GITHUB_SERVER_URL && process.env.GITHUB_RUN_ID
+        ? `${process.env.GITHUB_SERVER_URL}/${process.env.GITHUB_REPOSITORY}/actions/runs/${process.env.GITHUB_RUN_ID}`
+        : undefined,
+      reportName: 'Playwright Test Run',
+    };
+    this.writeJson('executor.json', executor);
+  }
+
+  private hash(value: string): string {
+    return createHash('md5').update(value).digest('hex');
+  }
+
+  private writeJson(fileName: string, data: unknown) {
+    const filePath = path.join(this.resultsDir, fileName);
+    fs.writeFileSync(filePath, JSON.stringify(data, null, 2));
+  }
+}
+
+export default SimpleAllureReporter;


### PR DESCRIPTION
## Summary
- add a custom Allure reporter that emits Allure-compatible results for every Playwright run
- update the CI workflow to archive Allure artifacts and publish the HTML dashboard to GitHub Pages
- document the reporting flow and ignore generated Allure output directories

## Testing
- npx playwright test --list

------
https://chatgpt.com/codex/tasks/task_e_68d18e21fef8832a86dfccd494076fb0