### PR TITLE
Update Playwright Docker base image to 1.55.0

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM mcr.microsoft.com/playwright:v1.41.2-jammy
+FROM mcr.microsoft.com/playwright:v1.55.0-jammy
 
 WORKDIR /app
 


### PR DESCRIPTION
## Summary
- update the Dockerfile to use the Playwright 1.55.0 Jammy base image compatible with @playwright/test@1.55.x

## Testing
- `npx playwright test` *(fails: backend service http://backend:8000 unavailable in local environment)*

------
https://chatgpt.com/codex/tasks/task_e_68d1a915d24c832ab35293d6444384f8