### PR TITLE
Remove unused campaign POM helpers

### DIFF
--- a/tests/e2e/pom/CampaignListPage.ts
+++ b/tests/e2e/pom/CampaignListPage.ts
@@ -28,8 +28,4 @@ export class CampaignListPage {
   get deletionSuccessToast(): Locator {
     return this.page.getByText("Campaign deleted successfully");
   }
-
-  get contentSection(): Locator {
-    return this.page.locator("div").filter({ has: this.heading }).first();
-  }
 }

--- a/tests/e2e/pom/NewCampaignPage.ts
+++ b/tests/e2e/pom/NewCampaignPage.ts
@@ -39,23 +39,7 @@ export class NewCampaignPage {
     await this.objectiveInput.press("Enter");
   }
 
-  objectiveItem(text: string): Locator {
-    return this.page
-      .locator("div")
-      .filter({
-        hasText: text,
-        has: this.page.locator("button"),
-      })
-      .first();
-  }
-
   async submit() {
     await this.createButton.click();
-  }
-
-  get missingConnectorError(): Locator {
-    return this.page.getByText(
-      "Please select a SUT connector before creating the campaign",
-    );
   }
 }


### PR DESCRIPTION
## Summary
- remove the unused campaign objective item helper from the new campaign page object model
- drop the unused content section getter from the campaign list page object model

## Testing
- npm run test -- --list

------
https://chatgpt.com/codex/tasks/task_e_68d1a924a464832a8a21ad10066dc066