### PR TITLE
Replace login wait with readiness check

### DIFF
--- a/tests/ui/login-homepage.spec.ts
+++ b/tests/ui/login-homepage.spec.ts
@@ -17,7 +17,7 @@ test.describe('Credential login flow', () => {
 
     await expect(page.getByRole('heading', { name: 'Sign in to PeithoTest' })).toBeVisible();
 
-    await page.waitForTimeout(7_000);
+    await expect(page.getByLabel('Username')).toBeEnabled();
 
     await page.getByLabel('Username').fill(adminCredentials.username);
     await page.getByLabel('Password').fill(adminCredentials.password);


### PR DESCRIPTION
## Summary
- replace the login UI test's fixed timeout with an assertion that the Username field is enabled before interacting with it

## Testing
- npm run test:ui:smoke *(fails: Project(s) "ui-smoke" not found. Available projects: "chromium", "firefox", "api")*

------
https://chatgpt.com/codex/tasks/task_e_68d1a9624ba0832aa9a092419a2ed373